### PR TITLE
Add teleop script with dual cameras

### DIFF
--- a/teleoperate_so101_two_cameras.sh
+++ b/teleoperate_so101_two_cameras.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Teleoperate the SO101 robot with overhead and wrist cameras
+# Adjust camera device paths and serial IDs to match your setup.
+
+python -m lerobot.teleoperate \
+    --robot.type=so101_follower \
+    --robot.port=/dev/ttyACM0 \
+    --robot.id=follower \
+    --robot.cameras="{ overhead: {type: opencv, index_or_path: /dev/video6, width: 640, height: 480, fps: 30}, wrist: {type: opencv, index_or_path: /dev/video4, width: 640, height: 480, fps: 30}}" \
+    --teleop.type=so101_leader \
+    --teleop.port=/dev/ttyACM1 \
+    --teleop.id=leader
+


### PR DESCRIPTION
## Summary
- add `teleoperate_so101_two_cameras.sh` for controlling SO101 with an overhead and wrist camera

## Testing
- `pytest tests/test_control_robot.py::test_teleoperate -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685622d1762883328c1cb2d40dfe51a8